### PR TITLE
autotools: avoid errors due to missing files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.65])
 AC_INIT([xl4gptp], [1.2.3], [shiro@excelfore.com])
 AC_SUBST(PACKAGE_DESC,"Excelfore gptp daemon and libary")
 
-AM_INIT_AUTOMAKE([-Wall -Werror subdir-objects])
+AM_INIT_AUTOMAKE([-Wall -Werror subdir-objects foreign])
 AM_PROG_AR
 LT_PREREQ([2.2])
 LT_INIT([static])


### PR DESCRIPTION
without setting foreign in AM_INIT_AUTOMAKE autotools will complain if no AUTHORS, Changelog and NEWS file exist. Instead of generating them with a custom tool, just use the non-gnu foreign setting.

This facilitates build system integration